### PR TITLE
GNUstep Build on Windows and with gcc

### DIFF
--- a/Source/CFRunLoop.c
+++ b/Source/CFRunLoop.c
@@ -27,6 +27,10 @@
    Boston, MA 02110-1301, USA.
 */
 
+#if defined (__MINGW64__)
+// from MSYS2 package mingw-w64-x86_64-libblocksruntime-swift
+#include <Block.h>
+#endif
 #include "config.h"
 #include "CoreFoundation/CFRuntime.h"
 #include "CoreFoundation/CFRunLoop.h"

--- a/Source/CFSocket.c
+++ b/Source/CFSocket.c
@@ -595,7 +595,7 @@ CFSocketSendData (CFSocketRef s, CFDataRef address, CFDataRef data,
   tv.tv_sec = (int) floor(timeout);
   tv.tv_usec = (timeout - tv.tv_sec) * 1000000;
   
-  err = setsockopt(s->_socket, SOL_SOCKET, SO_SNDTIMEO, &tv,
+  err = setsockopt(s->_socket, SOL_SOCKET, SO_SNDTIMEO, (char *) &tv,
                    sizeof(struct timeval));
   
   if (err != 0)

--- a/Source/CFTimeZone.c
+++ b/Source/CFTimeZone.c
@@ -537,7 +537,7 @@ CFTimeZoneCopyDefault (void)
     {
       CFTimeZoneRef new;
       new = CFTimeZoneCopySystem(); /* FIXME */
-      if (GSAtomicCompareAndSwapPointer(&_kCFTimeZoneDefault, NULL, new) != NULL)
+      if (GSAtomicCompareAndSwapPointer((void**) &_kCFTimeZoneDefault, NULL, new) != NULL)
         CFRelease (new);
     }
   
@@ -548,7 +548,7 @@ void
 CFTimeZoneSetDefault (CFTimeZoneRef tz)
 {
   CFTimeZoneRef old;
-  old = GSAtomicCompareAndSwapPointer(&_kCFTimeZoneDefault,
+  old = GSAtomicCompareAndSwapPointer((void**) &_kCFTimeZoneDefault,
                                       _kCFTimeZoneDefault, CFRetain (tz));
   if (old != NULL)
     CFRelease (old);
@@ -561,7 +561,7 @@ CFTimeZoneCopySystem (void)
     {
       CFTimeZoneRef new;
       new = CFTimeZoneCreateWithTimeIntervalFromGMT (NULL, 0.0); /* FIXME */
-      if (GSAtomicCompareAndSwapPointer(&_kCFTimeZoneSystem, NULL, new) != NULL)
+      if (GSAtomicCompareAndSwapPointer((void**) &_kCFTimeZoneSystem, NULL, new) != NULL)
         CFRelease (new);
     }
   
@@ -574,7 +574,7 @@ CFTimeZoneResetSystem (void)
   if (_kCFTimeZoneSystem != NULL)
     {
       CFTimeZoneRef old;
-      old = GSAtomicCompareAndSwapPointer(&_kCFTimeZoneSystem,
+      old = GSAtomicCompareAndSwapPointer((void**) &_kCFTimeZoneSystem,
                                           _kCFTimeZoneSystem, NULL);
       if (old != NULL)
         CFRelease (old);
@@ -816,7 +816,7 @@ CFTimeZoneCopyAbbreviationDictionary (void)
       new = CFDictionaryCreateCopy (NULL, dict);
       CFRelease (dict);
       
-      if (GSAtomicCompareAndSwapPointer(&_kCFTimeZoneAbbreviationDictionary,
+      if (GSAtomicCompareAndSwapPointer((void**) &_kCFTimeZoneAbbreviationDictionary,
           NULL, new) != NULL)
         CFRelease (new);
     }
@@ -828,7 +828,7 @@ void
 CFTimeZoneSetAbbreviationDictionary (CFDictionaryRef dict)
 {
   CFDictionaryRef old;
-  old = GSAtomicCompareAndSwapPointer(&_kCFTimeZoneAbbreviationDictionary,
+  old = GSAtomicCompareAndSwapPointer((void**) &_kCFTimeZoneAbbreviationDictionary,
                                       _kCFTimeZoneAbbreviationDictionary,
                                       CFDictionaryCreateCopy (NULL, dict));
   if (old != NULL)


### PR DESCRIPTION
# GNUstep Build on Windows and with gcc

## What

This pull request restores successful building of GNUstep on Windows and with gcc.

## Why

GNUstep must successfully build, in order to build AmiShare.

## How

Modifications were made to 3 libs-corebase/Source/*.c files.
These modifications were tested by building GNUstep on Windows with gcc and Ubuntu with clang and gcc.

### Change details

A header was included in CFRunLoop.c for BlocksRuntime LIB.  Casts were added to CFSocket.c and CFTimeZone.c.

Without the modification in CFRunLoop.c, GNUstep libs-corebase will not build under Windows mingw-w64-x86.

Without the remaining casting modifications, GNUstep libs-corebase will not build with the latest gcc compiler.

## Caveats

## Missed anything?

- [x] Explain the purpose of this PR
- [x] Self reviewed the PR
- [] Informed of breaking changes, testing and migrations (if applicable)
- [] Updated documentation (if applicable)
- [] Attached screenshots (if applicable)